### PR TITLE
Allow limiting videos to download in a YouTube playlist

### DIFF
--- a/download-youtube-video/README.md
+++ b/download-youtube-video/README.md
@@ -1,16 +1,30 @@
-# YouTube Video Downloader
+# YouTube video downloader
 
 ## Steps:
 
 1. Define the download parameters using [data.json](./data.json).
-1. Run [download_youtube_video.exe](./download_youtube_video.exe) to download a YouTube video/playlist.
+1. Run [download_youtube_video.exe](./download_youtube_video.exe) to download YouTube videos/playlists.
 
-## Potential values for [data.json](./data.json)
+## Parameters in [data.json](./data.json)
 
-| Parameter            | Potential value                                                                                                                                                                                                                                                                    | Notes                                                                                                             |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| yt_videos            | https://<span>www</span>.youtube.com/watch?v=_<span style="color: orange">&lt;video_id&gt;</span>_ <br/> https://<span>www</span>.youtube.com/watch?v=_<span style="color: orange">&lt;video_id&gt;</span>_&list=_<span style="color: orange">&lt;playlist_id&gt;</span>_          | List of YouTube videos to be downloaded.                                                                          |
-| yt_playlists         | https://<span>www</span>.youtube.com/playlist?list=_<span style="color: orange">&lt;playlist_id&gt;</span>_ <br/> https://<span>www</span>.youtube.com/watch?v=_<span style="color: orange">&lt;video_id&gt;</span>_&list=_<span style="color: orange">&lt;playlist_id&gt;</span>_ | List of YouTube playlists to be downloaded.                                                                       |
-| download_location    | ./youtube-downloads                                                                                                                                                                                                                                                                | Absolute/Relative path to your preferred download directory. <br/> Please prefer '/' instead of '\\' in the path. |
-| download_file_format | mp3 _or_ mp4                                                                                                                                                                                                                                                                       | File format of your downloaded file.                                                                              |
-| archive              | _Read Only_                                                                                                                                                                                                                                                                        | List of YouTube videos & playlists that have been downloaded and are being kept as historical data.               |
+- `yt_videos`: List of YouTube videos to be downloaded
+  - Format: https://<span>www</span>.youtube.com/watch?v=_&lt;video_id&gt;_&list=_&lt;playlist_id&gt;_
+    - Mandatory input: _&lt;video_id&gt;_
+    - Optional input: _&lt;playlist_id&gt;_
+  - Examples:
+    - https://www.youtube.com/watch?v=_k-F-MMvQV4
+    - https://www.youtube.com/watch?v=DC471a9qrU4&list=PL0vfts4VzfNiI1BsIK5u7LpPaIDKMJIDN
+- `yt_playlists`: List of YouTube playlists to be downloaded
+  - Format: https://<span>www</span>.youtube.com/playlist?list=_&lt;playlist_id&gt;_&limit=_&lt;video_download_limit&gt;_ `OR` https://<span>www</span>.youtube.com/watch?v=_&lt;video_id&gt;_&list=_&lt;playlist_id&gt;_&limit=_&lt;video_download_limit&gt;_
+    - Mandatory input: _&lt;playlist_id&gt;_
+    - Optional input: _&lt;video_download_limit&gt;_
+  - Examples:
+    - https://www.youtube.com/playlist?list=PL0vfts4VzfNiI1BsIK5u7LpPaIDKMJIDN
+    - https://www.youtube.com/watch?v=DC471a9qrU4&list=PL0vfts4VzfNiI1BsIK5u7LpPaIDKMJIDN&limit=10
+- `download_location`: Absolute/Relative path to your preferred download directory
+  - Use `/` instead of `\` in the path
+  - Example: ./youtube-downloads
+- `download_file_format`: File format of your downloaded file
+  - mp3
+  - mp4
+- `archive`: List of YouTube videos & playlists that have been downloaded and are being kept as historical data

--- a/download-youtube-video/data.json
+++ b/download-youtube-video/data.json
@@ -4,7 +4,7 @@
       "https://www.youtube.com/watch?v=_k-F-MMvQV4"
     ],
     "yt_playlists": [
-      "https://www.youtube.com/playlist?list=PL0vfts4VzfNiI1BsIK5u7LpPaIDKMJIDN"
+      "https://www.youtube.com/playlist?list=PL0vfts4VzfNiI1BsIK5u7LpPaIDKMJIDN&limit=10"
     ]
   },
   "download_location": "./youtube-downloads",

--- a/download-youtube-video/download_youtube_video.py
+++ b/download-youtube-video/download_youtube_video.py
@@ -78,10 +78,18 @@ if(len(videos) > 0):
 if(len(playlists) > 0):
     createDownloadLocation(location)
     for playlistURL in playlists:
+        try:
+            videoDownloadLimit = int(playlistURL.split("&limit=")[1].split("&")[0])
+        except IndexError as ie:
+            videoDownloadLimit = 2**31 - 1 # Maximum int value for int32 variable
         playlistObj = Playlist(playlistURL)
         isPlaylistDownloaded = True
+        numberOfVideosDownloaded = 0
         for videoObj in playlistObj.videos:
+            if(numberOfVideosDownloaded >= videoDownloadLimit):
+                break
             isPlaylistDownloaded = isPlaylistDownloaded and downloadVideo(location, fileFormat, videoObj, playlistObj)
+            numberOfVideosDownloaded += 1
         if(isPlaylistDownloaded):
             updateArchive(playlistURL, "playlist")
 


### PR DESCRIPTION
- Allow the user to specify the number of videos to be downloaded from a given playlist
- This enables the user to download only the specified section of the playlist (say the first 10 videos by title)